### PR TITLE
[BugFix]App will crash when sharing files on Android N or above.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -81,6 +81,16 @@
 
         <service android:name=".component.UpdateService"/>
 
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="com.codeest.geeknews.fileprovider"
+            android:grantUriPermissions="true"
+            android:exported="false">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/fileprovidepaths" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/codeest/geeknews/app/Constants.java
+++ b/app/src/main/java/com/codeest/geeknews/app/Constants.java
@@ -48,6 +48,8 @@ public class Constants {
 
     public static final String BUGLY_ID = "257700f3f8";
 
+    public static final String FILE_PROVIDER_AUTHORITY="com.codeest.geeknews.fileprovider";
+
     //================= PATH ====================
 
     public static final String PATH_DATA = App.getInstance().getCacheDir().getAbsolutePath() + File.separator + "data";

--- a/app/src/main/java/com/codeest/geeknews/util/SystemUtil.java
+++ b/app/src/main/java/com/codeest/geeknews/util/SystemUtil.java
@@ -8,7 +8,9 @@ import android.graphics.Bitmap;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.MediaStore;
+import android.support.v4.content.FileProvider;
 import android.text.TextUtils;
 import android.view.View;
 
@@ -80,6 +82,10 @@ public class SystemUtil {
         File imageFile = new File(fileDir,fileName);
         Uri uri = Uri.fromFile(imageFile);
         if (isShare && imageFile.exists()) {
+            if (Build.VERSION.SDK_INT >= 24) {
+                uri = FileProvider.getUriForFile(context.getApplicationContext(),
+                        Constants.FILE_PROVIDER_AUTHORITY, imageFile);
+            }
             return uri;
         }
         try {
@@ -102,6 +108,10 @@ public class SystemUtil {
             e.printStackTrace();
         }
         context.sendBroadcast(new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE,uri));
+        if (Build.VERSION.SDK_INT >= 24) {
+            uri = FileProvider.getUriForFile(context.getApplicationContext(),
+                    Constants.FILE_PROVIDER_AUTHORITY, imageFile);
+        }
         return uri;
     }
 

--- a/app/src/main/res/xml/fileprovidepaths.xml
+++ b/app/src/main/res/xml/fileprovidepaths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path
+        name="files_path"
+        path="codeest/GeekNews/" />
+</paths>


### PR DESCRIPTION
For apps targeting Android 7.0, the Android framework enforces the StrictMode API policy that prohibits exposing `file://` URIs outside your app. If an intent containing a file URI leaves your app, the app fails with a `FileUriExposedException` exception.

Reference: https://developer.android.com/about/versions/nougat/android-7.0-changes

Best Regards